### PR TITLE
Updates for installation in a folder. Spanish language added

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -7,6 +7,8 @@ return [
      |--------------------------------------------------------------------------
      |
      | General settings for configuring the PageBuilder.
+     | If you install phpb with Composer, general.assets_url line must be:
+     | 'assets_url' => '/vendor/hansschouten/phpagebuilder/dist',
      |
      */
     'general' => [

--- a/lang/en.php
+++ b/lang/en.php
@@ -40,6 +40,7 @@ return [
         'render-thumbs' => 'Render Thumbnails',
     ],
     'pagebuilder' => [
+        'filter-placeholder' => 'Filter',
         'loading-text' => 'Loading pagebuilder..',
         'style-no-element-selected' => 'Select an element to modify the style.',
         'trait-no-element-selected' => 'Select an element to modify any attributes.',

--- a/lang/es.php
+++ b/lang/es.php
@@ -1,0 +1,133 @@
+<?php
+
+return [
+    'auth' => [
+        'title' => 'Webuilder Manager',
+        'username' => 'Usuario',
+        'password' => 'Contraseña',
+        'login-button' => 'Entrar',
+        'invalid-credentials' => 'Usuario o contraseña Inválidos',
+    ],
+    'website-manager' => [
+        'title' => 'Webuilder Manager',
+        'logout' => 'Salir',
+        'pages' => 'Páginas',
+        'menus' => 'Menús',
+        'name' => 'Nombre',
+        'page-title' => 'Título de la Página',
+        'route' => 'URL',
+        'layout' => 'Diseño',
+        'actions' => 'Acciones',
+        'view' => 'Ver',
+        'edit' => 'Editar',
+        'remove' => 'Borrar',
+        'add-new-page' => 'Nueva página',
+        'edit-page' => 'Editar página',
+        'back' => 'Volver',
+        'save-changes' => 'Guardar cambios',
+        'theme' => 'Tema',
+        'visible-in-page-overview' => 'visible en vista de página',
+        'page-created' => 'Página creada correctamente',
+        'page-updated' => 'Página acyualizada correctamente',
+        'page-deleted' => 'Página eliminada',
+
+        'settings' => 'Ajustes',
+        'website-languages' => 'Idiomas del sitio',
+        'languages-selector-placeholder' => 'Selecciona uno o más idiomas',
+        'save-settings' => 'Guardar ajustes',
+        'settings-updated' => 'Ajustes actualizados correctamente',
+        'pagebuilder-block-images' => 'Listado de bloques',
+        'render-thumbs' => 'Mostrar Miniaturas',
+    ],
+    'pagebuilder' => [
+        'filter-placeholder' => 'Filtrar',
+        'loading-text' => 'Cargando Webuilder..',
+        'style-no-element-selected' => 'Selecciona un elemento para modificar su estilo.',
+        'trait-no-element-selected' => 'Selecciona un elemento para modificar sus atributos.',
+        'trait-settings' => 'Ajustes',
+        'default-category' => 'General',
+        'view-blocks' => 'Bloques',
+        'view-settings' => 'Ajustes',
+        'view-style-manager' => 'Gestor de Estilos',
+        'save-page' => 'Guardar',
+        'view-page' => 'Ver',
+        'go-back' => 'Volver',
+        'page' => 'Página',
+        'page-content' => 'Contenidos de la Página',
+        'toastr-changes-saved' => 'Cambios guardados',
+        'toastr-saving-failed' => 'Error al guardar los cambios',
+        'toastr-component-update-failed' => 'Error al cargar componente',
+        'toastr-switching-language-failed' => 'Error al cambiar de idioma',
+        'yes' => 'Si',
+        'no' => 'No',
+        'trait-manager' => [
+            'link' => [
+                'text' => 'Texto',
+                'target' => '¿Abrir en otra pestaña?'
+            ],
+            'no-settings' => 'Este bloque no tiene ajustes.'
+        ],
+        'selector-manager' => [
+            'label' => 'clases CSS',
+            'states-label' => 'Diseño para',
+            'selected-label' => 'Seleccinado',
+            'state-hover' => 'Elemento hover',
+            'state-active' => 'Elemento click',
+            'state-nth' => 'Elemento par/impar',
+        ],
+        'style-manager' => [
+            'sectors' => [
+                'position' => 'Posición',
+                'background' => 'Fondo',
+                'advanced' => 'Avanzado',
+            ],
+            'properties' => [
+                'position' => [
+                    'width' => 'Ancho',
+                    'min-width' => 'Mínimo',
+                    'max-width' => 'Máximo',
+                    'height' => 'Alto',
+                    'min-height' => 'Mínimo',
+                    'max-height' => 'Máximo',
+                    'padding' => [
+                        'name' => 'Relleno',
+                        'properties' => [
+                            'padding-top' => 'Padding arriba',
+                            'padding-right' => 'Padding derecho',
+                            'padding-bottom' => 'Padding abajo',
+                            'padding-left' => 'Padding izquierdo'
+                        ]
+                    ],
+                    'margin' => [
+                        'name' => 'Margen',
+                        'properties' => [
+                            'margin-top' => 'Margin arriba',
+                            'margin-right' => 'Margin derecho',
+                            'margin-bottom' => 'Margin abajo',
+                            'margin-left' => 'Margin izquierdo'
+                        ]
+                    ],
+                    'text-align' => [
+                        'name' => 'Alineación Texto'
+                    ]
+                ],
+                'background' => [
+                    'background-color' => 'Color de Fondo',
+                    'background' => 'Fondo',
+                ]
+            ]
+        ],
+        'asset-manager' => [
+            'modal-title' => 'Seleciona Imágen',
+            'drop-files' => 'Arrastra aquí los archivos o click para subirlos',
+            'add-image' => 'Añadir Imágenge',
+        ],
+    ],
+    'languages' => [
+        'en' => 'Inglés',
+        'nl' => 'Holandés',
+        'es' => 'Español',
+        'fr' => 'Francés',
+        'de' => 'Alemán',
+    ],
+];

--- a/lang/es.php
+++ b/lang/es.php
@@ -101,10 +101,10 @@ return [
                     'margin' => [
                         'name' => 'Margen',
                         'properties' => [
-                            'margin-top' => 'Margin arriba',
-                            'margin-right' => 'Margin derecho',
-                            'margin-bottom' => 'Margin abajo',
-                            'margin-left' => 'Margin izquierdo'
+                            'margin-top' => 'Margen arriba',
+                            'margin-right' => 'Margen derecho',
+                            'margin-bottom' => 'Margen abajo',
+                            'margin-left' => 'Margen izquierdo'
                         ]
                     ],
                     'text-align' => [

--- a/lang/nl.php
+++ b/lang/nl.php
@@ -40,6 +40,7 @@ return [
         'render-thumbs' => 'Blok afbeeldingen genereren',
     ],
     'pagebuilder' => [
+        'filter-placeholder' => 'Filter',
         'loading-text' => 'Bewerkmodus laden..',
         'style-no-element-selected' => 'Selecteer een element om de opmaak aan te passen.',
         'trait-no-element-selected' => 'Selecteer een element om de eigenschappen aan te passen.',

--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -51,7 +51,7 @@ if (! function_exists('phpb_theme_asset')) {
     function phpb_theme_asset($path)
     {
         $themeFolder = phpb_config('theme.folder_url') . '/' . phpb_config('theme.active_theme');
-        return $themeFolder . '/' . $path;
+        return phpb_full_url($themeFolder . '/' . $path);
     }
 }
 

--- a/src/Modules/GrapesJS/resources/views/pagebuilder.php
+++ b/src/Modules/GrapesJS/resources/views/pagebuilder.php
@@ -139,5 +139,5 @@ require __DIR__ . '/grapesjs/trait-manager.php';
 
 <div id="block-search">
     <i class="fa fa-search"></i>
-    <input type="text" class="form-control" placeholder="Filter">
+    <input type="text" class="form-control" placeholder="<?= phpb_trans('pagebuilder.filter-placeholder') ?>">
 </div>

--- a/src/Modules/WebsiteManager/resources/views/overview.php
+++ b/src/Modules/WebsiteManager/resources/views/overview.php
@@ -58,7 +58,7 @@ $settingsTabActive = isset($_GET['tab']) && $_GET['tab'] === 'settings' ? 'activ
                                         <?= phpb_e($page->getRoute()) ?>
                                     </td>
                                     <td class="actions">
-                                        <a href="<?= phpb_e(phpb_full_url(($page->getRoute())) ?>" target="_blank" class="btn btn-light btn-sm">
+                                        <a href="<?= phpb_e(phpb_full_url($page->getRoute())) ?>" target="_blank" class="btn btn-light btn-sm">
                                             <span><?= phpb_trans('website-manager.view') ?></span> <i class="fas fa-eye"></i>
                                         </a>
                                         <a href="<?= phpb_url('pagebuilder', ['page' => $page->getId()]) ?>" class="btn btn-primary btn-sm">

--- a/src/Modules/WebsiteManager/resources/views/overview.php
+++ b/src/Modules/WebsiteManager/resources/views/overview.php
@@ -58,7 +58,7 @@ $settingsTabActive = isset($_GET['tab']) && $_GET['tab'] === 'settings' ? 'activ
                                         <?= phpb_e($page->getRoute()) ?>
                                     </td>
                                     <td class="actions">
-                                        <a href="<?= phpb_e($page->getRoute()) ?>" target="_blank" class="btn btn-light btn-sm">
+                                        <a href="<?= phpb_e(phpb_full_url(($page->getRoute())) ?>" target="_blank" class="btn btn-light btn-sm">
                                             <span><?= phpb_trans('website-manager.view') ?></span> <i class="fas fa-eye"></i>
                                         </a>
                                         <a href="<?= phpb_url('pagebuilder', ['page' => $page->getId()]) ?>" class="btn btn-primary btn-sm">

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -9,6 +9,6 @@ class UploadedFile
      */
     public function getUrl()
     {
-        return phpb_config('general.uploads_url') . '/' . $this->public_id . '/' . $this->original_file;
+        return phpb_full_url(phpb_config('general.uploads_url') . '/' . $this->public_id . '/' . $this->original_file);
     }
 }


### PR DESCRIPTION
If you install phpb for instance at yourdomain.com/foldername (or localhost/foldername), then your general.base_url must include folder's name at the end: http://yourdomain.com/foldername, or http://localhost/foldername.
Added spanish (Spain) translation.
Corrected and included on languages an embedded placeholder. This way, you can see it in any selected language correctly.