### PR TITLE
Add extension support to PHPageBuilder. Allow blocks, layouts & assets to be added outside of a theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,60 @@ An alternative method is adding the `phpb-blocks-container` attribute to a html 
 </div>
 ```
 
+## Extending PHPageBuilder
+
+PHPageBuilder allows you to create new blocks and layouts for your theme very easily. This is great for building specific websites & templates, however if you use PHPageBuilder in a CMS environment, you probably want to provide Plugins / Modules the ability to create their own blocks without modifying your theme's pre-existing components.
+
+PHPageBuilder allows you to register blocks, layouts and assets (CSS, JS) from Plugins, Composer Packages or through any other environment.
+
+### Adding a New Block
+
+```php
+/**
+ * @param string $slug - A Unique identifier for the block. Prefix author to avoid conflict.
+ * @param string $directoryPath - Path to the directory of the Block.
+ */
+\PHPageBuilder\Extensions::registerBlock($slug, $directoryPath);
+
+// Registering an example block:
+
+\PHPageBuilder\Extensions::registerBlock('foo-navbar', MY_PLUGIN_DIRECTORY . '/blocks/foo-navbar');
+```
+
+### Adding a New Layout
+
+```php
+/**
+ * @param string $slug - A Unique identifier for the layout. Prefix author to avoid conflict.
+ * @param string $directoryPath - Path to the directory of the Layout.
+ */
+\PHPageBuilder\Extensions::registerLayout($slug, $directoryPath);
+
+// Registering an example layout:
+
+\PHPageBuilder\Extensions::registerLayout('foo-master', MY_PLUGIN_DIRECTORY . '/layouts/foo-master');
+```
+
+### Adding Assets (CSS & JS)
+```php
+/**
+ * @param string $src                           - URL of the Asset file.
+ * @param string $type                          - 'style' or 'script' 
+ * @param string $location                      - 'header' or 'footer'
+ * @param array['$key' => '$value'] $attributes - Array of attributes to add to the tag.
+ */
+\PHPageBuilder\Extensions::registerAsset($src, $type, $location, $attributes = []);
+
+// Registering assets:
+
+\PHPageBuilder\Extensions::registerAsset('/assets/bootstrap.css', 'style', 'header');
+\PHPageBuilder\Extensions::registerAsset('/assets/alpine.min.js', 'script', 'header', [
+    'defer' => true
+]);
+```
+
+Blocks & Layouts are created in the same manner as described in [Create A Theme](#create-a-theme), but they aren't limited to any theme directory.
+
 ## Customize PHPageBuilder
 
 PHPagebuilder is build with customization in mind. It comes with an extensive example config file in wich you can easily adapt the pagebuilder to your needs.

--- a/lang/en.php
+++ b/lang/en.php
@@ -37,7 +37,7 @@ return [
         'save-settings' => 'Save settings',
         'settings-updated' => 'Settings successfully updated',
         'pagebuilder-block-images' => 'Pagebuilder block thumbnails',
-        'render-thumbs' => 'Render Thumbnails',
+        'render-thumbs' => 'Render Thumbnails'
     ],
     'pagebuilder' => [
         'filter-placeholder' => 'Filter',

--- a/src/Contracts/PageBuilderContract.php
+++ b/src/Contracts/PageBuilderContract.php
@@ -54,4 +54,11 @@ interface PageBuilderContract
      * @return string
      */
     public function customScripts(string $location, string $scripts = null);
+
+    /**
+     * Set a theme for the page builder.
+     * 
+     * @param ThemeContract $theme
+     */
+    public function setTheme(ThemeContract $theme);
 }

--- a/src/Contracts/WebsiteManagerContract.php
+++ b/src/Contracts/WebsiteManagerContract.php
@@ -28,4 +28,9 @@ interface WebsiteManagerContract
      * Render the website manager menu settings (add/edit menu form).
      */
     public function renderMenuSettings();
+
+    /**
+     * Render the welcome page.
+     */
+    public function renderWelcomePage();
 }

--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -136,7 +136,7 @@ if (! function_exists('phpb_trans')) {
      *
      * @param $key
      * @param array $parameters
-     * @return string
+     * @return string|array
      */
     function phpb_trans($key, $parameters = [])
     {

--- a/src/Core/helpers.php
+++ b/src/Core/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use PHPageBuilder\Extensions;
+
 if (! function_exists('phpb_e')) {
     /**
      * Encode HTML special characters in a string.
@@ -535,5 +537,23 @@ if (! function_exists('phpb_autoload')) {
 
         // include class files starting in the src directory
         require __DIR__ . '/../' . $fileName;
+    }
+}
+
+if( ! function_exists('phpb_registered_assets_header') ) {
+    function phpb_registered_assets($location = 'header') {
+        $assets = $location == 'header' ? Extensions::getHeaderAssets() : Extensions::getFooterAssets();
+
+        foreach($assets as $asset) {
+            $attributes = '';
+            foreach($asset['attributes'] as $key => $value)
+                $attributes .= ' ' . $key . '="' . $value . '"';
+
+            if($asset['type'] == 'style') { ?>
+                <link rel="stylesheet" href="<?= $asset['src'] ?>" <?= $attributes ?> />
+            <?php } else { ?>
+                <script type="text/javascript" src="<?= $asset['src'] ?>" <?= $attributes ?>></script>
+            <?php }
+        }
     }
 }

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -14,6 +14,26 @@ class Extensions {
      */
     protected static array $layouts = [];
 
+    protected static array $assets = [
+        'header' => [],
+        'footer' => []
+    ];
+
+    /**
+     * Register an asset.
+     * @param string $src
+     * @param string $type
+     * @param string $location
+     * @param array['$key' => '$value'] $attributes
+     */
+    public static function registerAsset(string $src, string $type, string $location = 'header', array $attributes = []) {
+        self::$assets[$location][] = [
+            'src' => $src,
+            'type' => $type,
+            'attributes' => $attributes
+        ];
+    }
+
     /**
      * Register a single block.
      * @param string $slug
@@ -75,5 +95,19 @@ class Extensions {
      */
     public static function getLayout(string $id) {
         return isset(self::$layouts[$id]) ? self::$layouts[$id] : null;
+    }
+
+    /**
+     * Get all header assets.
+     */
+    public static function getHeaderAssets() {
+        return self::$assets['header'];
+    }
+
+    /**
+     * Get all footer assets.
+     */
+    public static function getFooterAssets() {
+        return self::$assets['footer'];
     }
 }

--- a/src/Extensions.php
+++ b/src/Extensions.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace PHPageBuilder;
+
+class Extensions {
+
+    /**
+     * Blocks that can be added by plugins / composer packages.
+     */
+    protected static array $blocks  = [];
+
+    /**
+     * Layouts that can be added by plugins / composer pckages.
+     */
+    protected static array $layouts = [];
+
+    /**
+     * Register a single block.
+     * @param string $slug
+     * @param string $directoryPath
+     */
+    public static function registerBlock(string $slug, string $directoryPath) {
+        self::$blocks[$slug] = $directoryPath;
+    }
+
+    /**
+     * Register a single layout.
+     * @param string $slug
+     * @param string $directoryPath
+     */
+    public static function registerLayout(string $slug, string $directoryPath) {
+        self::$layouts[$slug] = $directoryPath;
+    }
+
+    /**
+     * Register multiple blocks at once.
+     * @param array['$slug' => '$directoryPath'] $blocks
+     */
+
+    public static function addBlocks(array $blocks) {
+        self::$blocks = array_merge(self::$blocks, $blocks);
+    }
+
+    /**
+     * Register multiple blocks at once.
+     * @param array['$slug' => '$directoryPath'] $layouts
+     */
+    public static function addLayouts(array $layouts) {
+        self::$layouts = array_merge(self::$layouts, $layouts);
+    }
+
+    /**
+     * Get all blocks.
+     */
+    public static function getBlocks() : array {
+        return self::$blocks;
+    }
+
+    /**
+     * Get all layouts.
+     */
+    public static function getLayouts() : array {
+        return self::$layouts;
+    }
+
+    /**
+     * Get a single block.
+     */
+    public static function getBlock(string $id) {
+        return isset(self::$blocks[$id]) ? self::$blocks[$id] : null;
+    }
+
+    /**
+     * Get a single layout.
+     */
+    public static function getLayout(string $id) {
+        return isset(self::$layouts[$id]) ? self::$layouts[$id] : null;
+    }
+}

--- a/src/Modules/GrapesJS/Block/BlockRenderer.php
+++ b/src/Modules/GrapesJS/Block/BlockRenderer.php
@@ -4,6 +4,7 @@ namespace PHPageBuilder\Modules\GrapesJS\Block;
 
 use PHPageBuilder\Contracts\PageContract;
 use PHPageBuilder\Contracts\ThemeContract;
+use PHPageBuilder\Extensions;
 use PHPageBuilder\ThemeBlock;
 
 class BlockRenderer
@@ -69,7 +70,13 @@ class BlockRenderer
      */
     public function renderWithSlug(string $blockSlug, $blockData = null, $id = null)
     {
-        $block = new ThemeBlock($this->theme, $blockSlug);
+        $block = null;
+
+        if($path = Extensions::getBlock($blockSlug))
+            $block = new ThemeBlock($this->theme, $path, true, $blockSlug);
+        else
+            $block = new ThemeBlock($this->theme, $blockSlug);
+
         return $this->render($block, $blockData, $id);
     }
 

--- a/src/Modules/GrapesJS/Block/BlockRenderer.php
+++ b/src/Modules/GrapesJS/Block/BlockRenderer.php
@@ -70,12 +70,10 @@ class BlockRenderer
      */
     public function renderWithSlug(string $blockSlug, $blockData = null, $id = null)
     {
-        $block = null;
+        $block = ($path = Extensions::getBlock($blockSlug)) 
+                    ? new ThemeBlock($this->theme, $path, true, $blockSlug) 
+                    : new ThemeBlock($this->theme, $blockSlug);
 
-        if($path = Extensions::getBlock($blockSlug))
-            $block = new ThemeBlock($this->theme, $path, true, $blockSlug);
-        else
-            $block = new ThemeBlock($this->theme, $blockSlug);
 
         return $this->render($block, $blockData, $id);
     }

--- a/src/Modules/GrapesJS/PageBuilder.php
+++ b/src/Modules/GrapesJS/PageBuilder.php
@@ -11,6 +11,7 @@ use PHPageBuilder\Modules\GrapesJS\Upload\Uploader;
 use PHPageBuilder\Repositories\PageRepository;
 use PHPageBuilder\Repositories\UploadRepository;
 use Exception;
+use PHPageBuilder\Extensions;
 
 class PageBuilder implements PageBuilderContract
 {
@@ -34,7 +35,10 @@ class PageBuilder implements PageBuilderContract
      */
     public function __construct()
     {
-        $this->theme = phpb_instance('theme', [phpb_config('theme'), phpb_config('theme.active_theme')]);
+        $this->theme = phpb_instance('theme', [
+            phpb_config('theme'), 
+            phpb_config('theme.active_theme')
+        ]);
     }
 
     /**

--- a/src/Modules/GrapesJS/PageRenderer.php
+++ b/src/Modules/GrapesJS/PageRenderer.php
@@ -250,12 +250,9 @@ class PageRenderer
      */
     public function renderBlock($slug, $id = null, $context = null, $maxDepth = 25)
     {
-        $themeBlock = null;
-
-        if( $blockPath = Extensions::getBlock($slug) )
-            $themeBlock = new ThemeBlock($this->theme, $blockPath, true, $slug);
-        else
-            $themeBlock = new ThemeBlock($this->theme, $slug);
+        $themeBlock = ($blockPath = Extensions::getBlock($slug)) 
+                        ? new ThemeBlock($this->theme, $blockPath, true, $slug) 
+                        : new ThemeBlock($this->theme, $slug);
 
         $id = $id ?? $themeBlock->getSlug();
         $context = $context[$id] ?? $this->pageBlocksData[$id] ?? [];

--- a/src/Modules/GrapesJS/PageRenderer.php
+++ b/src/Modules/GrapesJS/PageRenderer.php
@@ -7,6 +7,7 @@ use PHPageBuilder\Contracts\ThemeContract;
 use PHPageBuilder\Modules\GrapesJS\Block\BlockRenderer;
 use PHPageBuilder\ThemeBlock;
 use Exception;
+use PHPageBuilder\Extensions;
 
 class PageRenderer
 {
@@ -110,7 +111,12 @@ class PageRenderer
     public function getPageLayoutPath()
     {
         $layout = basename($this->page->getLayout());
+
         $layoutPath = $this->theme->getFolder() . '/layouts/' . $layout . '/view.php';
+
+        if($path = Extensions::getLayout($layout))
+            $layoutPath = $path . '/view.php';
+
         return file_exists($layoutPath) ? $layoutPath : null;
     }
 
@@ -244,7 +250,13 @@ class PageRenderer
      */
     public function renderBlock($slug, $id = null, $context = null, $maxDepth = 25)
     {
-        $themeBlock = new ThemeBlock($this->theme, $slug);
+        $themeBlock = null;
+
+        if( $blockPath = Extensions::getBlock($slug) )
+            $themeBlock = new ThemeBlock($this->theme, $blockPath, true, $slug);
+        else
+            $themeBlock = new ThemeBlock($this->theme, $slug);
+
         $id = $id ?? $themeBlock->getSlug();
         $context = $context[$id] ?? $this->pageBlocksData[$id] ?? [];
 

--- a/src/Modules/WebsiteManager/WebsiteManager.php
+++ b/src/Modules/WebsiteManager/WebsiteManager.php
@@ -4,6 +4,7 @@ namespace PHPageBuilder\Modules\WebsiteManager;
 
 use PHPageBuilder\Contracts\PageContract;
 use PHPageBuilder\Contracts\WebsiteManagerContract;
+use PHPageBuilder\Extensions;
 use PHPageBuilder\Repositories\PageRepository;
 use PHPageBuilder\Repositories\SettingRepository;
 
@@ -147,7 +148,10 @@ class WebsiteManager implements WebsiteManagerContract
     public function renderPageSettings(PageContract $page = null)
     {
         $action = isset($page) ? 'edit' : 'create';
-        $theme = phpb_instance('theme', [phpb_config('theme'), phpb_config('theme.active_theme')]);
+        $theme = phpb_instance('theme', [
+            phpb_config('theme'), 
+            phpb_config('theme.active_theme')
+        ]);
 
         $viewFile = 'page-settings';
         require __DIR__ . '/resources/layouts/master.php';

--- a/src/PHPageBuilder.php
+++ b/src/PHPageBuilder.php
@@ -465,7 +465,7 @@ class PHPageBuilder
 
         // only allow specific extensions
         $ext = pathinfo($requestedFile, PATHINFO_EXTENSION);
-        if (! in_array($ext, ['js', 'css', 'jpg', 'png'])) die('Asset not found');
+        if (! in_array($ext, ['js', 'css', 'jpg', 'png', 'svg'])) die('Asset not found');
 
         $contentTypes = [
             'js' => 'application/javascript; charset=utf-8',

--- a/src/PHPageBuilder.php
+++ b/src/PHPageBuilder.php
@@ -82,7 +82,12 @@ class PHPageBuilder
 
         // init the default page builder, active theme and page router
         $this->pageBuilder = phpb_instance('pagebuilder');
-        $this->theme = phpb_instance('theme', [phpb_config('theme'), phpb_config('theme.active_theme')]);
+
+        $this->theme = phpb_instance('theme', [
+            phpb_config('theme'), 
+            phpb_config('theme.active_theme')
+        ]);
+
         $this->router = phpb_instance('router');
 
         // load translations in the language that is currently active

--- a/src/Repositories/SettingRepository.php
+++ b/src/Repositories/SettingRepository.php
@@ -23,6 +23,7 @@ class SettingRepository extends BaseRepository implements SettingRepositoryContr
     {
         $this->destroyAll();
 
+
         foreach ($data as $key => $value) {
             $isArray = is_array($value);
             if ($isArray) {

--- a/src/ThemeBlock.php
+++ b/src/ThemeBlock.php
@@ -25,15 +25,29 @@ class ThemeBlock
     protected $blockSlug;
 
     /**
+     * @var bool $isExtension
+     * Determines if a block was registered by an extension.
+     */
+    protected $isExtension;
+
+    /**
+     * @var bool $extensionSlug
+     * Custom slug in case of extension.
+     */
+    protected $extensionSlug;
+
+    /**
      * Theme constructor.
      *
      * @param ThemeContract $theme         the theme this block belongs to
      * @param string $blockSlug
      */
-    public function __construct(ThemeContract $theme, string $blockSlug)
+    public function __construct(ThemeContract $theme, string $blockSlug, bool $isExtension = false, string $extensionSlug = null)
     {
         $this->theme = $theme;
         $this->blockSlug = $blockSlug;
+        $this->isExtension = $isExtension;
+        $this->extensionSlug = $extensionSlug;
 
         $this->config = [];
         if (file_exists($this->getFolder() . '/config.php')) {
@@ -53,7 +67,7 @@ class ThemeBlock
      */
     public function getFolder()
     {
-        return $this->theme->getFolder() . '/blocks/' . basename($this->blockSlug);
+        return (!$this->isExtension) ? $this->theme->getFolder() . '/blocks/' . basename($this->blockSlug) : $this->blockSlug;
     }
 
     /**
@@ -214,7 +228,7 @@ class ThemeBlock
      */
     public function getSlug()
     {
-        return $this->blockSlug;
+        return ! $this->isExtension ? $this->blockSlug : $this->extensionSlug;
     }
 
     /**

--- a/src/ThemeBlock.php
+++ b/src/ThemeBlock.php
@@ -77,6 +77,10 @@ class ThemeBlock
      */
     protected function getNamespace()
     {
+        // Return Namespace from the Config file of the Block if it is an extension. Used for Extensions.
+        if( isset( $this->config['namespace'] ) )
+            return $this->config['namespace'];
+
         // Return Namespace from Config file if exists;
         if( phpb_config('theme.namespace') )
             return phpb_config('theme.namespace');

--- a/src/ThemeBlock.php
+++ b/src/ThemeBlock.php
@@ -63,6 +63,12 @@ class ThemeBlock
      */
     protected function getNamespace()
     {
+        // Return Namespace from Config file if exists;
+        if( phpb_config('theme.namespace') )
+            return phpb_config('theme.namespace');
+
+        // Get namespace from directory structure if not provided:
+
         $themesPath = phpb_config('theme.folder');
         $themesFolderName = basename($themesPath);
         $blockFolder = $this->getFolder();

--- a/src/ThemeLayout.php
+++ b/src/ThemeLayout.php
@@ -22,15 +22,29 @@ class ThemeLayout
     protected $layoutSlug;
 
     /**
+     * @var bool $isExtension
+     * Determines if a block was registered by an extension.
+     */
+    protected $isExtension;
+
+    /**
+     * @var bool $extensionSlug
+     * Custom slug in case of extension.
+     */
+    protected $extensionSlug;
+
+    /**
      * Theme ThemeLayout.
      *
      * @param ThemeContract $theme         the theme this layout belongs to
      * @param string $layoutSlug
      */
-    public function __construct(ThemeContract $theme, string $layoutSlug)
+    public function __construct(ThemeContract $theme, string $layoutSlug, bool $isExtension = false, string $extensionSlug = null)
     {
         $this->theme = $theme;
         $this->layoutSlug = $layoutSlug;
+        $this->isExtension = $isExtension;
+        $this->extensionSlug = $extensionSlug;
 
         $this->config = [];
         if (file_exists($this->getFolder() . '/config.php')) {
@@ -45,7 +59,9 @@ class ThemeLayout
      */
     public function getFolder()
     {
-        return $this->theme->getFolder() . '/layouts/' . $this->layoutSlug;
+        print_r($this->layoutSlug);
+
+        return !$this->isExtension ? $this->theme->getFolder() . '/layouts/' . $this->layoutSlug : $this->layoutSlug;
     }
 
     /**
@@ -65,7 +81,7 @@ class ThemeLayout
      */
     public function getSlug()
     {
-        return $this->layoutSlug;
+        return !$this->isExtension ? $this->layoutSlug : $this->extensionSlug;
     }
 
     /**


### PR DESCRIPTION
When using PHPageBuilder in a CMS-environment, often you want plugins / modules to have the ability to create their own blocks, layouts and assets. This functionality should now be available in PHPageBuilder.

This pr adds an Extension class that can be used to register blocks / layouts from anywhere in the project. This could be used from within a plugin, composer package or more.

A new helper `phpb_registered_assets($location = 'header');` is also added to get an array of all assets registered by extensions for use within layouts.